### PR TITLE
Adjust unit movement speed with tick duration

### DIFF
--- a/client/core/src/com/cows/game/Application.kt
+++ b/client/core/src/com/cows/game/Application.kt
@@ -11,9 +11,9 @@ class Application : ApplicationAdapter() {
     companion object {
         const val WIDTH = Map.WIDTH * TileModel.WIDTH
         const val HEIGHT = Map.HEIGHT * TileModel.HEIGHT
-        const val TICK_DURATION = 1f // in seconds
     }
 
+    val tickDuration = 0.5f // in seconds
     private lateinit var gameTickProcessor: GameTickProcessor
 
     override fun create() {
@@ -26,9 +26,11 @@ class Application : ApplicationAdapter() {
 
     override fun render() {
         val deltaTime = Gdx.graphics.deltaTime
-        gameTickProcessor.update(deltaTime)
-        Updater.update(deltaTime)
-        Renderer.render(deltaTime)
+        gameTickProcessor.update(deltaTime, tickDuration)
+
+        val tickAdjustedDeltaTime = deltaTime / tickDuration
+        Updater.update(tickAdjustedDeltaTime)
+        Renderer.render(tickAdjustedDeltaTime)
     }
 
     override fun dispose() {

--- a/client/core/src/com/cows/game/controllers/UnitController.kt
+++ b/client/core/src/com/cows/game/controllers/UnitController.kt
@@ -1,7 +1,6 @@
 package com.cows.game.controllers
 
 import com.badlogic.gdx.math.Vector2
-import com.cows.game.Application
 import com.cows.game.Map
 import com.cows.game.models.UnitModel
 import com.cows.game.views.UnitView

--- a/client/core/src/com/cows/game/controllers/UnitController.kt
+++ b/client/core/src/com/cows/game/controllers/UnitController.kt
@@ -1,6 +1,7 @@
 package com.cows.game.controllers
 
 import com.badlogic.gdx.math.Vector2
+import com.cows.game.Application
 import com.cows.game.Map
 import com.cows.game.models.UnitModel
 import com.cows.game.views.UnitView

--- a/client/core/src/com/cows/game/roundSimulation/GameTickProcessor.kt
+++ b/client/core/src/com/cows/game/roundSimulation/GameTickProcessor.kt
@@ -22,10 +22,10 @@ class GameTickProcessor (private val roundSimulation: JsonRoundSimulation) {
         roundSimulation.eventLog.map { concretizeTick(it) }.forEach { eventLog.add(it) }
     }
 
-    fun update(deltaTime: Float) {
+    fun update(deltaTime: Float, tickDuration: Float) {
         tickTimer += deltaTime
-        if (tickTimer >= Application.TICK_DURATION) {
-            tickTimer -= Application.TICK_DURATION
+        if (tickTimer >= tickDuration) {
+            tickTimer -= tickDuration
             if (eventLog.size == 0) {
                 println("empty event log")
                 return


### PR DESCRIPTION
Closes #9 

Unit movement speed wasn't adjusted to tick duration. This is fixed by dividing speed with TICK_DURATION. However, that means we have to remember to do this operation for every deltaTime based movement. I made a change to Application, where it adjusts deltaTime to TICK_DURATION (now named tickDuration), and passes the adjusted deltaTime to Updater and Renderer. This makes it very easy to change the tickDuration during the game, for example if we want some sort of slow-motion effect or let the user speed up the round. 