### PR TITLE
Implement tower targeting

### DIFF
--- a/client/core/src/com/cows/game/controllers/TowerController.kt
+++ b/client/core/src/com/cows/game/controllers/TowerController.kt
@@ -1,18 +1,29 @@
 package com.cows.game.controllers
 
+import com.badlogic.gdx.math.MathUtils
+import com.badlogic.gdx.math.Vector2
 import com.cows.game.models.TowerModel
 import com.cows.game.views.Renderable
 import com.cows.game.views.TowerView
 
 class TowerController(val model: TowerModel): Updatable() {
+    private var currentTarget: UnitController? = null
+
     override fun update(deltaTime: Float) {
-       // TODO("Not yet implemented")
+        if (currentTarget == null) return
+
+        val targetPos = currentTarget!!.model.position
+        val startPos = model.tileCoordinate.toVector2()
+        val directionToTarget = Vector2(targetPos.x - startPos.x, targetPos.y - startPos.y)
+
+        model.rotation = MathUtils.atan2(directionToTarget.y, directionToTarget.x) * MathUtils.radDeg
     }
 
     val renderableView = TowerView(model)
 
     fun target(unit: UnitController) {
-        // TODO: Implement this
+        currentTarget = unit
+        model.hasTarget = true
     }
 
     fun attack() {

--- a/client/core/src/com/cows/game/controllers/TowerController.kt
+++ b/client/core/src/com/cows/game/controllers/TowerController.kt
@@ -26,6 +26,11 @@ class TowerController(val model: TowerModel): Updatable() {
         model.hasTarget = true
     }
 
+    fun removeTarget() {
+        currentTarget = null
+        model.hasTarget = false
+    }
+
     fun attack() {
         // TODO: Implement this
     }

--- a/client/core/src/com/cows/game/controllers/UnitController.kt
+++ b/client/core/src/com/cows/game/controllers/UnitController.kt
@@ -6,7 +6,7 @@ import com.cows.game.models.UnitModel
 import com.cows.game.views.UnitView
 
 
-class UnitController(private val model: UnitModel): Updatable() {
+class UnitController(val model: UnitModel): Updatable() {
     private lateinit var view: UnitView
     private var target = Vector2();
     var currentPathIndex = 0;

--- a/client/core/src/com/cows/game/models/TowerModel.kt
+++ b/client/core/src/com/cows/game/models/TowerModel.kt
@@ -6,10 +6,9 @@ import com.cows.game.enums.TowerType
 data class TowerModel (
     val type: TowerType,
     val tileCoordinate: Coordinate,
-    var rotation: Float
+    var rotation: Float,
+    var hasTarget: Boolean
 
 ) {
-    constructor(type: TowerType, tileCoordinate: Coordinate) : this(type, tileCoordinate, 0f)
-
-
+    constructor(type: TowerType, tileCoordinate: Coordinate) : this(type, tileCoordinate, 0f, false)
 }

--- a/client/core/src/com/cows/game/roundSimulation/Action.kt
+++ b/client/core/src/com/cows/game/roundSimulation/Action.kt
@@ -24,8 +24,11 @@ class EmptyAction(): Action() {
     override val type = ActionType.NONE
 }
 
-data class TargetAction(val tower: TowerController, val unit: UnitController): Action() {
-    override fun processAction() = tower.target(unit)
+data class TargetAction(val tower: TowerController, val unit: UnitController?): Action() {
+    override fun processAction() {
+        if (unit == null) tower.removeTarget()
+        else tower.target(unit)
+    }
     override val type = ActionType.TARGET
 }
 

--- a/client/core/src/com/cows/game/roundSimulation/GameTickProcessor.kt
+++ b/client/core/src/com/cows/game/roundSimulation/GameTickProcessor.kt
@@ -43,7 +43,7 @@ class GameTickProcessor (private val roundSimulation: JsonRoundSimulation) {
     private fun concretizeAction(jsonAction: JsonAction): Action {
         return try {
             when (jsonAction.verb) {
-                ActionType.TARGET -> TargetAction(towerList[jsonAction.subject]!!, unitList[jsonAction.obj]!!)
+                ActionType.TARGET -> TargetAction(towerList[jsonAction.subject]!!, unitList[jsonAction.obj])
                 ActionType.ATTACK -> AttackAction(towerList[jsonAction.subject]!!)
                 ActionType.MOVE -> MoveAction(unitList[jsonAction.subject]!!, Map.getTileAtPathIndex(jsonAction.obj!!))
                 ActionType.DIE -> DieAction(unitList[jsonAction.subject]!!)

--- a/client/core/src/com/cows/game/roundSimulation/rawJsonData/JsonTower.kt
+++ b/client/core/src/com/cows/game/roundSimulation/rawJsonData/JsonTower.kt
@@ -10,5 +10,5 @@ data class JsonTower (
     val position: Coordinate,
     val range: Float
  ) {
-    fun toTowerModel() = TowerModel(type, position, range)
+    fun toTowerModel() = TowerModel(type, position, range, false)
 }

--- a/client/core/src/com/cows/game/views/TowerView.kt
+++ b/client/core/src/com/cows/game/views/TowerView.kt
@@ -19,8 +19,12 @@ class TowerView(val model: TowerModel): Renderable() {
         turret.setOrigin(turret.width/2f, turret.height/2f)
     }
 
-    fun rotateTowardTarget(deltaTime: Float){
-        turret.rotate(100*deltaTime)
+    private fun rotateTowardTarget(deltaTime: Float){
+        if (!model.hasTarget) {
+            turret.rotate(100*deltaTime)
+            return
+        }
+        turret.rotation = model.rotation
     }
 
     override fun render(batch: SpriteBatch, deltaTime: Float) {

--- a/client/core/src/com/cows/game/views/TowerView.kt
+++ b/client/core/src/com/cows/game/views/TowerView.kt
@@ -6,9 +6,9 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch
 import com.cows.game.models.TileModel
 import com.cows.game.models.TowerModel
 
-class TowerView(val model: TowerModel): Renderable() {
-    val tower = Sprite(Texture("Towers/tower1.png"))
-    val turret = Sprite(Texture("Turrets/turret1.png"))
+class TowerView(private val model: TowerModel): Renderable() {
+    private val tower = Sprite(Texture("Towers/tower1.png"))
+    private val turret = Sprite(Texture("Turrets/turret1.png"))
 
     init {
         val pixel = model.tileCoordinate.toVector2()

--- a/client/roundSimulation.json
+++ b/client/roundSimulation.json
@@ -12,8 +12,8 @@
       "id": 1,
       "type": "WOOD",
       "position": {
-        "x": 12,
-        "y": 3
+        "x": 11,
+        "y": 6
       }
     }
   ],
@@ -63,6 +63,11 @@
           "subject": 3,
           "verb": "SPAWN",
           "obj": 0
+        },
+        {
+          "subject": 1,
+          "verb": "TARGET",
+          "obj": 2
         }
       ]
     },

--- a/client/roundSimulation.json
+++ b/client/roundSimulation.json
@@ -91,6 +91,38 @@
           "obj": 0
         }
       ]
+    },
+    {
+      "actions": []
+    },
+    {
+      "actions": []
+    },
+    {
+      "actions": []
+    },
+    {
+      "actions": []
+    },
+    {
+      "actions": []
+    },
+    {
+      "actions": []
+    },
+    {
+      "actions": []
+    },
+    {
+      "actions": []
+    },
+    {
+      "actions": [
+        {
+          "subject": 1,
+          "verb": "TARGET"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Towers now listen to TargetAction from the event log and will rotate towards a target if they have one. I also changed TargetAction slightly to allow null target values. A null target means "remove your current target". I think this is a better solution than making a new action for removing targets. 