### PR TITLE
Simulation module cleanup

### DIFF
--- a/client/core/src/com/cows/game/roundSimulation/RoundSimulator.kt
+++ b/client/core/src/com/cows/game/roundSimulation/RoundSimulator.kt
@@ -18,10 +18,10 @@ class RoundSimulator {
     //TODO add gameState, to simulate money, store map etc.
     fun simulate(map : Map, defendInstruction : List<JsonTower>, attackInstruction : List<JsonUnit>) : JsonRoundSimulation {
 
-        var path = map.getPathCoordinates()
+        val path = Map.getPathCoordinates()
 
         //init simulation
-        var units = mutableListOf<UnitSimulationModel>()
+        val units = mutableListOf<UnitSimulationModel>()
         val towers = mutableListOf<TowerSimulationModel>()
 
         //TODO possibly split this up so they dont "spawn" at once

--- a/client/core/src/com/cows/game/roundSimulation/simulationModels/TowerSimulationModel.kt
+++ b/client/core/src/com/cows/game/roundSimulation/simulationModels/TowerSimulationModel.kt
@@ -19,14 +19,21 @@ class TowerSimulationModel(val id :Int, val position: Coordinate, range : Int, u
     fun setCooldown(){
         cooldown = timeBetweenAttacks
     }
+
     fun attack() {
         target!!.damage(damage)
     }
+
     fun targetInRange() : Boolean = target != null && pathIndicesInRange.contains(target!!.pathIndex)
 
 
     fun findPathIndicesInRange(range : Int, path : List<IntArray> ) : IntArray {
         //TODO implement, so that it only needs to check these positions
+    }
+
+    fun findNewTarget(): UnitSimulationModel? {
+        // TODO implement this
+        return null
     }
 
 


### PR DESCRIPTION
I tried to simplify the calculateTower method because it was huge and confusing. Do you think this is better? I've also made it so that calculateUnit and calculateTower returns a nullable JsonAction instead of adding one to currentTick inside the method. Personally I think this is a better way to write code because then a function does only one thing, i.e. receive an input and return an output. 

We still do actions though, such as setting new target or calling a tower's attack method, so ideally I think we should create SimulationActions, similar to Actions in the client. Then we can call each action's processAction method (which performs the actions I'm trying to move outside of calculateTower/calculateUnit), and finally we call a serializer to convert the SimulationAction to a JsonAction. It's a bit complicated to write in a PR, but I can explain IRL when we meet. 