### PR TITLE
Websocket fixes

### DIFF
--- a/client/core/src/com/cows/game/serverConnection/ServerConnection.kt
+++ b/client/core/src/com/cows/game/serverConnection/ServerConnection.kt
@@ -79,7 +79,7 @@ object ServerConnection {
                 is Frame.Text -> {
                     val message = Message.retrieveWSMessage(incoming)
                     println(message)
-                    if (message!!.opCode == OpCode.CONNECTED || message!!.opCode == OpCode.AWAIT){
+                    if (message!!.opCode == OpCode.CONNECTED){
                         isConnected = true
                     }
                 }

--- a/client/core/src/com/cows/game/serverConnection/ServerConnection.kt
+++ b/client/core/src/com/cows/game/serverConnection/ServerConnection.kt
@@ -54,6 +54,7 @@ object ServerConnection {
     suspend fun createGame(client: HttpClient){
         val createGameResponse = sendGameCreateRequest(client)
         val websocketClient = generateWebsocketClient(client)
+        println("created game with game code ${createGameResponse.gameJoinCode}")
         websocketSession = establishGameConnection(websocketClient,createGameResponse.userId,createGameResponse.gameCodeUUID)
 
     }


### PR DESCRIPTION
I've worked a bit on the websocket thingy and I think this works? Figured I'd do it as a PR so you can easily see all the changes. 

What I had to do was use the same client.webSocketSession method as before, but instead of using parameters for request type, host, port and path, I just inserted the whole URL. This seems to work both for ws and wss connections. 

I've also updated the environment variables to use full URLs, but I've made one variable for HTTP and one for WS (see env.example in assets folder). 

The app was crashing though. Apparently, in the while loop (while !isConnected inside establishGameConnection), a lot of the incoming frames were invalid (isFailure or isClosed), causing wsSession.incoming.receive() to throw an error. I fixed it by just saying continue if it's invalid, but I have no idea what all those invalid frames are and if we need them? Try logging when a frame is invalid. There's a lot of them!